### PR TITLE
Add logic to bypass lack of index file

### DIFF
--- a/.github/workflows/build-collection.yml
+++ b/.github/workflows/build-collection.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout files
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.gh_pat }}

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Check out current repository
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,6 +38,7 @@ jobs:
       # Make the branch fresh
       - name: Make the branch fresh
         run: |
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 
@@ -142,6 +143,7 @@ jobs:
       # Set up git checkout
       - name: Set up git checkout
         run: |
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 
@@ -242,6 +244,7 @@ jobs:
 
       - name: Login as jhudsl-robot
         run: |
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -172,7 +172,7 @@ jobs:
         run: |
           branch_name='preview-${{ github.event.pull_request.number }}'
           git diff origin/main -- docs >/dev/null && changes=true || changes=false
-          echo ::set-output name=changes::$changes
+          echo "changes=$changes" >> $GITHUB_OUTPUT
           git add . --force
           git commit -m 'Render preview' || echo "No changes to commit"
           git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
@@ -192,9 +192,9 @@ jobs:
         run: |
           course_name=$(head -n 1 student-guide/_bookdown.yml | cut -d'"' -f 2| tr " " "-")
           bookdown_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/index.html")
-          echo ::set-output name=bookdown_link::$bookdown_link
-          echo ::set-output name=time::$(date +'%Y-%m-%d')
-          echo ::set-output name=commit_id::$GITHUB_SHA
+          echo "bookdown_link=$bookdown_link" >> $GITHUB_OUTPUT
+          echo "time=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "commit_id=$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo ${{steps.commit.outputs.changes}}
 
       - name: Create or update comment

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout files
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout files
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Verify Dockerfiles changed?
         uses: tj-actions/verify-changed-files@v8.8

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -119,6 +119,7 @@ jobs:
 
       - name: Commit styled files
         run: |
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           git add \*.Rmd
           git commit -m 'Style Rmds' || echo "No changes to commit"
           git push origin || echo "No changes to commit"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,6 @@ jobs:
       # Make the branch fresh
       - name: Make the branch fresh
         run: |
-          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
         # Use the yaml-env-action action.
       - name: Load environment from YAML
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
@@ -223,7 +223,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Login as jhudsl-robot
         run: |
-
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 
@@ -127,6 +127,7 @@ jobs:
 
       - name: Login as jhudsl-robot
         run: |
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 
@@ -164,6 +165,7 @@ jobs:
 
       - name: Login as jhudsl-robot
         run: |
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 
@@ -230,6 +232,7 @@ jobs:
 
       - name: Login as jhudsl-robot
         run: |
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
         # Use the yaml-env-action action.
       - name: Load environment from YAML
@@ -65,7 +65,7 @@ jobs:
 
       - name: Checkout code from Leanpub repo
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ steps.git_repo_check.outputs.leanpub_repo }}
           token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Builds were failing because one of the repos was not an OTTR resource. It is a repo intended to hold WDL workflows, not necessarily educational content: https://github.com/fhdsl/AnVIL_WDLs

I'll likely end up creating an index.Rmd for this repo, but figured I should make a failsafe so the build completes without the index file and subs the repo name (however ugly that might be with underscores, etc).

Also did a bit of updating for `set-output` and bump checkout@v2 to v3.