### PR TITLE
Improve solution to auto-detecting google slides

### DIFF
--- a/Contribute.Rmd
+++ b/Contribute.Rmd
@@ -60,11 +60,7 @@ Finally, you should add any relevant topics, as they will be listed in the Colle
 
 Make sure you add any AnVIL "Shorts" videos you create to this playlist! https://www.youtube.com/playlist?list=PL6aYJ_0zJ4uCABkMngSYjPo_3c-nUUmio
 
-In order for Google Slides to get linked correctly, please also include this information at the end of your description:
-
-> You can see the slides for this video here: {link}
-
-For example:
+In order for Google Slides to get linked correctly, please include the link somewhere in your video description. For example, you could include text like this:
 
 > You can see the slides for this video here: https://docs.google.com/presentation/d/1IOOzvnKoTMJdRLFjCup_9FqQpumP07NwoBb9mIlD7lM/edit?usp=sharing
 

--- a/Contribute.Rmd
+++ b/Contribute.Rmd
@@ -47,7 +47,13 @@ Make sure you link to the website where your course is being rendered. For examp
 
 Finally, you should add any relevant topics, as they will be listed in the Collection table!
 
-![Add tags to the repository.](https://raw.githubusercontent.com/fhdsl/AnVIL_Collection/main/resources/screenshots/repo-tags.png)  
+![Add tags to the repository.](https://raw.githubusercontent.com/fhdsl/AnVIL_Collection/main/resources/screenshots/repo-tags.png)
+
+
+
+
+
+
 
 
 ## AnVIL Shorts {-} 

--- a/scripts/render_youtube_list.R
+++ b/scripts/render_youtube_list.R
@@ -19,9 +19,7 @@ make_youtube_shorts_table <- function() {
       # Extract slides link
       df$`Google Slides` <-
         df$snippet.description %>% 
-        str_extract_all("You can see the slides for this video here:.*") %>% 
-        str_remove_all("You can see the slides for this video here:") %>% 
-        str_trim() %>% # Remove whitespace
+        str_extract_all("https://docs.google.com/presentation/d/.*") %>%
         str_remove_all("\\.$") # Remove trailing period
       
       # Create Google Slides link w/ markdown magic


### PR DESCRIPTION
Not sure why I didn't think of it before, but it's much better to simply detect a link starting with "https://docs.google.com/presentation/d/" rather than finding the leading text "You can see the slides for this video here:.*".

This way uploaders to our channels won't have to worry about the leading text, just that the text is there.